### PR TITLE
Update nokogiri (CVE-2017-9050)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,14 +161,14 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
     mercenary (0.3.6)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     minima (2.1.1)
       jekyll (~> 3.3)
     minitest (5.10.3)
     multipart-post (2.0.0)
     net-dns (0.8.0)
-    nokogiri (1.6.8.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     octopress-autoprefixer (2.0.1)
@@ -212,4 +212,4 @@ DEPENDENCIES
   therubyracer
 
 BUNDLED WITH
-   1.15.4
+   1.16.1


### PR DESCRIPTION
Fixes a critical security issue flagged by GitHub.